### PR TITLE
Fix from_hdf5 for hex lattice with x orientation. Assorted other fixes.

### DIFF
--- a/docs/source/io_formats/geometry.rst
+++ b/docs/source/io_formats/geometry.rst
@@ -320,8 +320,8 @@ the following attributes or sub-elements:
 
   :orientation:
     The orientation of the hexagonal lattice. The string "x" indicates that two
-    sides of the lattice are perpendicular to the x-axis, whereas the string "y"
-    indicates that two sides are perpendicular to the y-axis.
+    sides of the lattice are parallel to the x-axis, whereas the string "y"
+    indicates that two sides are parallel to the y-axis.
 
     *Default*: "y"
 

--- a/include/openmc/lattice.h
+++ b/include/openmc/lattice.h
@@ -267,8 +267,8 @@ public:
 
 private:
   enum class Orientation {
-      y, //!< Flat side perpendicular to y-axis
-      x  //!< Flat side perpendicular to x-axis
+      y, //!< Flat side of lattice parallel to y-axis
+      x  //!< Flat side of lattice parallel to x-axis
   };
 
   //! Fill universes_ vector for 'y' orientation

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -228,37 +228,37 @@ class Lattice(IDManagerMixin, metaclass=ABCMeta):
                         # Add a list for this ring.
                         uarray[-1].append([])
 
-                        # Climb up the top-left.
-                        for i in range(r):
-                            uarray[-1][-1].append(universe_ids[z, y, a])
-                            a -= 1
-                            y += 1
-
-                        # Climb the left.
-                        for i in range(r):
-                            uarray[-1][-1].append(universe_ids[z, y, a])
-                            a -= 1
-
-                        # Climb down the bottom-left.
-                        for i in range(r):
-                            uarray[-1][-1].append(universe_ids[z, y, a])
-                            y -= 1
-
                         # Climb down the bottom-right.
                         for i in range(r):
                             uarray[-1][-1].append(universe_ids[z, y, a])
-                            a += 1
                             y -= 1
 
-                        # Climb up the right.
+                        # Climb across the bottom.
                         for i in range(r):
                             uarray[-1][-1].append(universe_ids[z, y, a])
-                            a += 1
+                            a -= 1
 
-                        # Climb up the top-right.
+                        # Climb up the bottom-left.
+                        for i in range(r):
+                            uarray[-1][-1].append(universe_ids[z, y, a])
+                            a -= 1
+                            y +=1
+
+                        # Climb up the top-left.
                         for i in range(r):
                             uarray[-1][-1].append(universe_ids[z, y, a])
                             y += 1
+
+                        # Climb across the top.
+                        for i in range(r):
+                            uarray[-1][-1].append(universe_ids[z, y, a])
+                            a += 1
+
+                        # Climb down the top-right.
+                        for i in range(r):
+                            uarray[-1][-1].append(universe_ids[z, y, a])
+                            a += 1
+                            y -= 1
 
                         # Move down to the next ring.
                         a -= 1
@@ -405,9 +405,11 @@ class Lattice(IDManagerMixin, metaclass=ABCMeta):
         ----------
         idx : Iterable of int
             Lattice element indices. For a rectangular lattice, the indices are
-            given in the :math:`(x,y)` or :math:`(x,y,z)` coordinate system.For
+            given in the :math:`(x,y)` or :math:`(x,y,z)` coordinate system. For
             hexagonal lattices, they are given in the :math:`x,\alpha` or
-            :math:`x,\alpha,z` coordinate systems.
+            :math:`x,\alpha,z` coordinate systems for "y" orientations and
+            :math:`\alpha,y` or :math:`\alpha,y,z` coordinate systems for "x"
+            orientations.
 
         Returns
         -------
@@ -947,8 +949,7 @@ class HexLattice(Lattice):
         string += '{0: <16}{1}{2}\n'.format('\tID', '=\t', self._id)
         string += '{0: <16}{1}{2}\n'.format('\tName', '=\t', self._name)
         string += '{0: <16}{1}{2}\n'.format('\tOrientation', '=\t',
-                                            "x" if (self._orientation == 'x')
-                                            else "y")
+                                            self._orientation)
         string += '{0: <16}{1}{2}\n'.format('\t# Rings', '=\t', self._num_rings)
         string += '{0: <16}{1}{2}\n'.format('\t# Axial', '=\t', self._num_axial)
         string += '{0: <16}{1}{2}\n'.format('\tCenter', '=\t',

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -1085,7 +1085,7 @@ class HexLattice(Lattice):
                 # Check the center ring.
                 if len(axial_slice[-1]) != 1:
                     msg = 'HexLattice ID={0:d} has the wrong number of ' \
-                          'elements in the innermost ring.Only 1 element is ' \
+                          'elements in the innermost ring. Only 1 element is ' \
                           'allowed in the innermost ring.'.format(self._id)
                     raise ValueError(msg)
 
@@ -1093,7 +1093,7 @@ class HexLattice(Lattice):
                 for r in range(self._num_rings-1):
                     if len(axial_slice[r]) != 6*(self._num_rings - 1 - r):
                         msg = 'HexLattice ID={0:d} has the wrong number of ' \
-                              'elements in ring number{1:d}(counting from the '\
+                              'elements in ring number {1:d} (counting from the '\
                               'outermost ring). This ring should have {2:d} ' \
                               'elements.'.format(self._id, r,
                                                  6*(self._num_rings - 1 - r))
@@ -1788,15 +1788,15 @@ class HexLattice(Lattice):
         setting the :attr:`HexLattice.universes` property. For example,running
         this method with num_rings=3 will return the similar diagram::
 
-                      (0, 4)      (0, 3)      (0, 2)
-
-                (0, 5)      (1, 2)      (1, 1)      (0, 1)
-
-          (0, 6)      (1, 3)      (2, 0)      (1, 0)      (0, 0)
+                      (0, 8)      (0, 9)      (0,10)
 
                 (0, 7)      (1, 4)      (1, 5)      (0,11)
 
-                      (0, 8)      (0, 9)      (0,10)
+          (0, 6)      (1, 3)      (2, 0)      (1, 0)      (0, 0)
+
+                (0, 5)      (1, 2)      (1, 1)      (0, 1)
+
+                      (0, 4)      (0, 3)      (0, 2)
 
         Parameters
         ----------

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -36,9 +36,7 @@
 int openmc_init(int argc, char* argv[], const void* intracomm)
 {
   using namespace openmc;
-  
-  char cCurrentPath[256];
-  
+
 #ifdef OPENMC_MPI
   // Check if intracomm was passed
   MPI_Comm comm;

--- a/src/relaxng/geometry.rnc
+++ b/src/relaxng/geometry.rnc
@@ -36,7 +36,6 @@ element geometry {
       attribute dimension { list { xsd:positiveInteger+ } }) &
     (element lower_left { list { xsd:double+ } } | attribute lower_left { list { xsd:double+ } }) &
     (element pitch { list { xsd:double+ } } | attribute pitch { list { xsd:double+ } }) &
-    (element orientation { ( "x" | "y" ) } | attribute orientation { ( "x" | "y" ) })? &
     (element universes { list { xsd:int+ } } | attribute universes { list { xsd:int+ } }) &
     (element outer { xsd:int } | attribute outer { xsd:int })?
   }*
@@ -49,6 +48,7 @@ element geometry {
     (element n_axial { xsd:int } | attribute n_axial { xsd:int })? &
     (element center { list { xsd:double+ } } | attribute center { list { xsd:double+ } }) &
     (element pitch { list { xsd:double+ } } | attribute pitch { list { xsd:double+ } }) &
+    (element orientation { ( "x" | "y" ) } | attribute orientation { ( "x" | "y" ) })? &
     (element universes { list { xsd:int+ } } | attribute universes { list { xsd:int+ } }) &
     (element outer { xsd:int } | attribute outer { xsd:int })?
   }*

--- a/src/relaxng/geometry.rnc
+++ b/src/relaxng/geometry.rnc
@@ -36,7 +36,7 @@ element geometry {
       attribute dimension { list { xsd:positiveInteger+ } }) &
     (element lower_left { list { xsd:double+ } } | attribute lower_left { list { xsd:double+ } }) &
     (element pitch { list { xsd:double+ } } | attribute pitch { list { xsd:double+ } }) &
-    (element orient { ( "OX" ) } | attribute orient { ( "OX" ) })? &
+    (element orientation { ( "x" | "y" ) } | attribute orientation { ( "x" | "y" ) })? &
     (element universes { list { xsd:int+ } } | attribute universes { list { xsd:int+ } }) &
     (element outer { xsd:int } | attribute outer { xsd:int })?
   }*

--- a/src/relaxng/geometry.rng
+++ b/src/relaxng/geometry.rng
@@ -294,22 +294,6 @@
               </list>
             </attribute>
           </choice>
-          <optional>
-            <choice>
-              <element name="orientation">
-                <choice>
-                  <value>x</value>
-                  <value>y</value>
-                </choice>
-              </element>
-              <attribute name="orientation">
-                <choice>
-                  <value>x</value>
-                  <value>y</value>
-                </choice>
-              </attribute>
-            </choice>
-          </optional>
           <choice>
             <element name="universes">
               <list>
@@ -414,6 +398,22 @@
               </list>
             </attribute>
           </choice>
+          <optional>
+            <choice>
+              <element name="orientation">
+                <choice>
+                  <value>x</value>
+                  <value>y</value>
+                </choice>
+              </element>
+              <attribute name="orientation">
+                <choice>
+                  <value>x</value>
+                  <value>y</value>
+                </choice>
+              </attribute>
+            </choice>
+          </optional>
           <choice>
             <element name="universes">
               <list>

--- a/src/relaxng/geometry.rng
+++ b/src/relaxng/geometry.rng
@@ -296,11 +296,17 @@
           </choice>
           <optional>
             <choice>
-              <element name="orient">
-                <value>OX</value>
+              <element name="orientation">
+                <choice>
+                  <value>x</value>
+                  <value>y</value>
+                </choice>
               </element>
-              <attribute name="orient">
-                <value>OX</value>
+              <attribute name="orientation">
+                <choice>
+                  <value>x</value>
+                  <value>y</value>
+                </choice>
               </attribute>
             </choice>
           </optional>

--- a/tests/regression_tests/lattice_hex_x/inputs_true.dat
+++ b/tests/regression_tests/lattice_hex_x/inputs_true.dat
@@ -119,8 +119,5 @@
       <parameters>-13.62546635287517 -13.62546635287517 0.0 13.62546635287517 13.62546635287517 10.0</parameters>
     </space>
   </source>
-  <output>
-    <summary>false</summary>
-  </output>
   <seed>22</seed>
 </settings>

--- a/tests/regression_tests/lattice_hex_x/test.py
+++ b/tests/regression_tests/lattice_hex_x/test.py
@@ -6,7 +6,6 @@ import numpy as np
 class HexLatticeOXTestHarness(PyAPITestHarness):
 
     def _build_inputs(self):
-
         materials = openmc.Materials()
 
         fuel_mat = openmc.Material(material_id=1, name="UO2")
@@ -195,7 +194,6 @@ class HexLatticeOXTestHarness(PyAPITestHarness):
         source.space = openmc.stats.Box(ll, ur)
         source.strength = 1.0
         settings.source = source
-        settings.output = {'summary': False}
         settings.batches = 10
         settings.inactive = 5
         settings.particles = 1000
@@ -204,6 +202,5 @@ class HexLatticeOXTestHarness(PyAPITestHarness):
 
 
 def test_lattice_hex_ox_surf():
-
     harness = HexLatticeOXTestHarness('statepoint.10.h5')
     harness.main()

--- a/tests/unit_tests/test_lattice.py
+++ b/tests/unit_tests/test_lattice.py
@@ -202,6 +202,13 @@ def test_get_universe(rlat2, rlat3, hlat2, hlat3):
     assert hlat2.get_universe((1, 0)) == u1
     assert hlat2.get_universe((-2, 2)) == u1
 
+    hlat2.orientation = 'x'
+    assert hlat2.get_universe((2, 0)) == u2
+    assert hlat2.get_universe((1, 0)) == u2
+    assert hlat2.get_universe((1, 1)) == u1
+    assert hlat2.get_universe((-1, 1)) == u1
+    hlat2.orientation = 'y'
+
     u1, u2, u3, outer = hlat3.univs
     assert hlat3.get_universe((0, 0, 0)) == u2
     assert hlat3.get_universe((0, 0, 1)) == u3
@@ -341,4 +348,6 @@ def test_xml_hex(hlat2, hlat3):
 def test_show_indices():
     for i in range(1, 11):
         lines = openmc.HexLattice.show_indices(i).split('\n')
+        assert len(lines) == 4*i - 3
+        lines_x = openmc.HexLattice.show_indices(i, 'x').split('\n')
         assert len(lines) == 4*i - 3


### PR DESCRIPTION
@dryuri92 Here are a few final fixes for the x-oriented hex lattice capability. I noticed that I missed `Lattice.from_hdf5` when switching the order of universes from counter-clockwise to clockwise. That's now fixed as well as a few other things.